### PR TITLE
Store executed trades as dict with timestamps as keys

### DIFF
--- a/src/order_matching/executed_trades.py
+++ b/src/order_matching/executed_trades.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import asdict
 
 import pandas as pd
@@ -11,13 +12,23 @@ from order_matching.trade import Trade
 
 class ExecutedTrades:
     def __init__(self, trades: list[Trade] = None) -> None:
-        self.trades: list[Trade] = list() if trades is None else trades
+        self._trades: dict[pd.Timestamp, list[Trade]] = defaultdict(list)
+        if trades:
+            self.add(trades=trades)
+
+    @property
+    def trades(self) -> list[Trade]:
+        trades = list()
+        for timestamp, same_time_trades in self._trades.items():
+            trades.extend(same_time_trades)
+        return trades
 
     def add(self, trades: list[Trade]) -> None:
-        self.trades.extend(trades)
+        for trade in trades:
+            self._trades[trade.timestamp].append(trade)
 
     def to_frame(self) -> DataFrame[TradeDataSchema]:
-        if len(self.trades) == 0:
+        if len(self._trades) == 0:
             return pd.DataFrame()
         else:
             return pd.DataFrame.from_records([asdict(trade) for trade in self.trades]).assign(

--- a/src/order_matching/executed_trades.py
+++ b/src/order_matching/executed_trades.py
@@ -27,6 +27,9 @@ class ExecutedTrades:
         for trade in trades:
             self._trades[trade.timestamp].append(trade)
 
+    def get(self, timestamp: pd.Timestamp) -> list[Trade]:
+        return self._trades[timestamp]
+
     def to_frame(self) -> DataFrame[TradeDataSchema]:
         if len(self._trades) == 0:
             return pd.DataFrame()

--- a/src/order_matching/executed_trades.py
+++ b/src/order_matching/executed_trades.py
@@ -19,7 +19,7 @@ class ExecutedTrades:
     @property
     def trades(self) -> list[Trade]:
         trades = list()
-        for timestamp, same_time_trades in self._trades.items():
+        for same_time_trades in self._trades.values():
             trades.extend(same_time_trades)
         return trades
 

--- a/tests/test_executed_trades.py
+++ b/tests/test_executed_trades.py
@@ -31,7 +31,7 @@ class TestExecutedTrades:
 
         executed_trades.add(trades=[second_trade, first_trade])
 
-        assert executed_trades.trades == [first_trade, second_trade, second_trade, first_trade]
+        assert executed_trades.trades == [first_trade, first_trade, second_trade, second_trade]
 
     def test_to_frame(self) -> None:
         executed_trades = ExecutedTrades()


### PR DESCRIPTION
## Issue

- It may be useful to access trades for a specific timestamp. The only way to obtain them now is through creation of a DataFrame and subsetting it later.

## Changes

- Store executed trades as dict with timestamps as keys.

## Change severity

- [ ] Major (breaking change)
- [X] Minor (new feature)
- [ ] Patch (improvement, bug fix)
