### PR TITLE
Fix the bug of converting to DataFrame when there are no trades

### DIFF
--- a/src/order_matching/executed_trades.py
+++ b/src/order_matching/executed_trades.py
@@ -31,10 +31,11 @@ class ExecutedTrades:
         return self._trades[timestamp]
 
     def to_frame(self) -> DataFrame[TradeDataSchema]:
-        if len(self._trades) == 0:
+        trades = self.trades
+        if len(trades) == 0:
             return pd.DataFrame()
         else:
-            return pd.DataFrame.from_records([asdict(trade) for trade in self.trades]).assign(
+            return pd.DataFrame.from_records([asdict(trade) for trade in trades]).assign(
                 **{
                     TradeDataSchema.side: lambda df: df[TradeDataSchema.side].astype(str),
                     TradeDataSchema.execution: lambda df: df[TradeDataSchema.execution].astype(str),

--- a/tests/test_executed_trades.py
+++ b/tests/test_executed_trades.py
@@ -53,6 +53,9 @@ class TestExecutedTrades:
 
     def test_to_frame(self) -> None:
         executed_trades = ExecutedTrades()
+
+        pd.testing.assert_frame_equal(executed_trades.to_frame(), pd.DataFrame())
+
         first_trade, second_trade = self._get_sample_trades()
         executed_trades.add(trades=[first_trade, second_trade])
 


### PR DESCRIPTION
## Issue

- In case no trades exist, `to_frame` throws an error.

## Changes

- Fix the bug of converting to DataFrame when there are no trades.

## Change severity

- [ ] Major (breaking change)
- [ ] Minor (new feature)
- [X] Patch (improvement, bug fix)
