### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,13 +12,17 @@ jobs:
   test:
     name: Run unit tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ "3.10", "3.11" ]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: pyproject.toml
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ authors = [
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Issue

- Latest version of Python is 3.11. Currently, only 3.10 is tested. Closes https://github.com/chintai-platform/OrderBookMatchingEngine/issues/5.

## Changes

- Add support for Python 3.11.

## Change severity

- [ ] Major (breaking change)
- [ ] Minor (new feature)
- [X] Patch (improvement, bug fix)
