### PR TITLE
Add dependency of build workflow step on test and code quality steps

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
         python-version: [ "3.10", "3.11" ]
     steps:
       - name: Check out repository code
@@ -53,6 +52,7 @@ jobs:
 
   build:
     name: Build wheels
+    needs: [ test, code-quality ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -56,8 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: pip install .[build]
       - name: Build wheels and source distribution
         run: |
           python -m pip install build


### PR DESCRIPTION
## Issue

- Release steps run independently from test and code quality. A failure in the later ones does not stop the release process.

## Changes

- Add dependency of build workflow step on test and code quality steps.
- Remove non-existent `build` installation.

## Change severity

- [ ] Major (breaking change)
- [ ] Minor (new feature)
- [X] Patch (improvement, bug fix)
