### PR TITLE
Add link to published docs in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install order-matching
 
 ## Documentation
 
-[order-book-matching-engine.readthedocs.io](http://order-book-matching-engine.readthedocs.io/)
+[order-book-matching-engine.readthedocs.io](https://order-book-matching-engine.readthedocs.io/)
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dynamic = ["version"]
 
 [project.urls]
 Source = "https://github.com/chintai-platform/OrderBookMatchingEngine"
+Documentation = "https://order-book-matching-engine.readthedocs.io/"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## Issue

- Link to published docs in pyproject.toml is missing.

## Changes

- Add link to published docs in pyproject.toml.

## Change severity

- [ ] Major (breaking change)
- [ ] Minor (new feature)
- [X] Patch (improvement, bug fix)
